### PR TITLE
Added SpikeInterfaceGenerator class

### DIFF
--- a/spikeinterface/spikeinterface_deepinterpolation.ipynb
+++ b/spikeinterface/spikeinterface_deepinterpolation.ipynb
@@ -1,0 +1,256 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4f136ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "\n",
+    "import spikeinterface.extractors as se\n",
+    "import spikeinterface.preprocessing as spre\n",
+    "import spikeinterface.widgets as sw\n",
+    "\n",
+    "# the generator is in the \"spikeinterface_generator.py\"\n",
+    "from spikeinterface_generator import SpikeInterfaceGenerator\n",
+    "\n",
+    "\n",
+    "\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33e1d6c6",
+   "metadata": {},
+   "source": [
+    "### Load NP2 dataset (and preprocess)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03da9c1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# example of data generation in spike interface\n",
+    "folder_path = \"/home/alessio/Documents/data/allen/npix-open-ephys/595262_2022-02-22_16-47-26/\"\n",
+    "recording = se.read_openephys(folder_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5a78ca4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rec_f = spre.bandpass_filter(recording)\n",
+    "rec_norm = spre.zscore(rec_f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87a7403a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sw.plot_timeseries(rec_f, backend=\"ipywidgets\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "893ba3ec",
+   "metadata": {},
+   "source": [
+    "### Test SpikeInterfaceGenerator behavior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e21b428f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "si_generator = SpikeInterfaceGenerator(rec_norm, batch_size=10, zscore=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab2c6235",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_0, output_0 = si_generator[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "345efb18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "si_generator.batch_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ce860f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_0.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb0dcef6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_0.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a629606",
+   "metadata": {},
+   "source": [
+    "### Perform small training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a729da9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deepinterpolation.trainor_collection import core_trainer\n",
+    "from deepinterpolation.network_collection import unet_single_ephys_1024\n",
+    "from deepinterpolation.generic import ClassLoader\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17ea7fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_frame_training = int(0 * rec_norm.sampling_frequency)\n",
+    "end_frame_training = int(2 * rec_norm.sampling_frequency)\n",
+    "start_frame_test = int(20 * rec_norm.sampling_frequency) \n",
+    "end_frame_test = int(21 * rec_norm.sampling_frequency)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f15bb1b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Training (from Training class)\n",
+    "output_folder = Path(\"test_training\")\n",
+    "output_folder.mkdir(exist_ok=True)\n",
+    "\n",
+    "training_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False, \n",
+    "                                                  start_frame=start_frame_training,\n",
+    "                                                  end_frame=end_frame_training)\n",
+    "test_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False, \n",
+    "                                              start_frame=start_frame_test,\n",
+    "                                              end_frame=end_frame_test)\n",
+    "\n",
+    "\n",
+    " # Those are parameters used for the network topology\n",
+    "network_params = dict()\n",
+    "network_params[\"type\"] = \"network\"\n",
+    "network_params[\n",
+    "    \"name\"\n",
+    "] = \"unet_single_ephys_1024\"  # Name of network topology in the collection\n",
+    "\n",
+    "network_json_path = output_folder / \"network_params.json\"\n",
+    "with open(network_json_path, \"w\") as f:\n",
+    "    json.dump(network_params, f)\n",
+    "\n",
+    "network_obj = ClassLoader(network_json_path)\n",
+    "data_network = network_obj.find_and_build()(network_json_path)\n",
+    "\n",
+    "training_params = dict()\n",
+    "training_params[\"loss\"] = \"mean_absolute_error\"\n",
+    "\n",
+    "training_params[\"model_string\"] = (\n",
+    "    \"unet_single_ephys_1024\"\n",
+    "    + \"_\"\n",
+    "    + training_params[\"loss\"]\n",
+    ")\n",
+    "training_params[\"output_dir\"] = str(output_folder)\n",
+    "# We pass on the uid\n",
+    "training_params[\"run_uid\"] = \"first_test\"\n",
+    "\n",
+    "# We convert to old schema\n",
+    "training_params[\"nb_gpus\"] = 1\n",
+    "training_params[\"type\"] = \"trainer\"\n",
+    "training_params[\"steps_per_epoch\"] = 10\n",
+    "training_params[\"period_save\"] = 5\n",
+    "training_params[\"apply_learning_decay\"] = 0\n",
+    "training_params[\"nb_times_through_data\"] = 1\n",
+    "training_params[\"learning_rate\"] = 0.0001\n",
+    "training_params[\"pre_post_frame\"] = 1\n",
+    "training_params[\"loss\"] = \"mean_absolute_error\"\n",
+    "training_params[\"nb_workers\"] = 1\n",
+    "\n",
+    "training_json_path = output_folder / \"training_params.json\"\n",
+    "with open(training_json_path, \"w\") as f:\n",
+    "    json.dump(training_params, f)\n",
+    "\n",
+    "\n",
+    "training_class = core_trainer(\n",
+    "    training_data_generator, test_data_generator, data_network,\n",
+    "    training_json_path\n",
+    ")\n",
+    "\n",
+    "print(\"created objects for training\")\n",
+    "training_class.run()\n",
+    "\n",
+    "print(\"training job finished - finalizing output model\")\n",
+    "training_class.finalize()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spikeinterface/spikeinterface_deepinterpolation.ipynb
+++ b/spikeinterface/spikeinterface_deepinterpolation.ipynb
@@ -9,6 +9,7 @@
    "source": [
     "import json\n",
     "import numpy as np\n",
+    "from pathlib import Path\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "\n",
@@ -18,7 +19,6 @@
     "\n",
     "# the generator is in the \"spikeinterface_generator.py\"\n",
     "from spikeinterface_generator import SpikeInterfaceGenerator\n",
-    "\n",
     "\n",
     "\n",
     "%matplotlib widget"
@@ -152,16 +152,18 @@
    "outputs": [],
    "source": [
     "start_frame_training = int(0 * rec_norm.sampling_frequency)\n",
-    "end_frame_training = int(2 * rec_norm.sampling_frequency)\n",
+    "end_frame_training = int(0.1 * rec_norm.sampling_frequency)\n",
     "start_frame_test = int(20 * rec_norm.sampling_frequency) \n",
-    "end_frame_test = int(21 * rec_norm.sampling_frequency)"
+    "end_frame_test = int(20.05 * rec_norm.sampling_frequency)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "f15bb1b2",
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "# Training (from Training class)\n",
@@ -229,6 +231,48 @@
     "\n",
     "print(\"training job finished - finalizing output model\")\n",
     "training_class.finalize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e90a864b",
+   "metadata": {},
+   "source": [
+    "### Test inference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95cf3d42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_input, original_data = test_data_generator[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc94efa9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = training_class.local_model.predict(sample_input)\n",
+    "output_data = test_data_generator.reshape_output(output)\n",
+    "input_data = original_data.squeeze().reshape(-1, recording.get_num_channels())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1834f749",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(ncols=2)\n",
+    "axs[0].imshow(input_data.T, origin=\"lower\", cmap=\"RdGy_r\")\n",
+    "axs[1].imshow(output_data.T, origin=\"lower\", cmap=\"RdGy_r\")"
    ]
   }
  ],

--- a/spikeinterface/spikeinterface_generator.py
+++ b/spikeinterface/spikeinterface_generator.py
@@ -1,0 +1,105 @@
+import tempfile
+import json
+import numpy as np
+
+import spikeinterface.preprocessing as spre
+
+from deepinterpolation.generator_collection import SequentialGenerator
+
+
+class SpikeInterfaceGenerator(SequentialGenerator):
+    """This generator is used when dealing with a SpikeInterface recording.
+    The desired shape controls the reshaping of the input data before convolutions."""
+
+    def __init__(self, recording, pre_frame=30, post_frame=30, pre_post_omission=1, desired_shape=(192, 2),
+                 batch_size=100, steps_per_epoch=10, zscore=True, start_frame=None, end_frame=None):
+        "Initialization"
+        
+        if zscore:
+            recording_z = spre.zscore(recording)
+        else:
+            recording_z = recording
+
+        self.recording = recording_z
+        self.total_samples = recording.get_num_samples()
+        assert len(desired_shape) == 2, "desired_shape should be 2D"
+        assert desired_shape[0] * desired_shape [1] == recording.get_num_channels(), \
+            f"The product of desired_shape dimensions should be the number of channels: {recording.get_num_channels()}"
+        self.desired_shape = desired_shape
+        
+        start_frame = start_frame if start_frame is not None else 0
+        end_frame = end_frame if end_frame is not None else self.total_samples
+        
+        assert end_frame > start_frame, "end_frame must be greater than start_frame"
+        
+        sequential_generator_params = dict()
+        sequential_generator_params["steps_per_epoch"] = steps_per_epoch
+        sequential_generator_params["pre_frame"] = pre_frame
+        sequential_generator_params["post_frame"] = post_frame
+        sequential_generator_params["batch_size"] = batch_size
+        sequential_generator_params["start_frame"] = start_frame
+        sequential_generator_params["end_frame"] = end_frame
+        sequential_generator_params["total_samples"] = self.total_samples
+        sequential_generator_params["pre_post_omission"] = pre_post_omission
+
+        json_path = tempfile.mktemp(suffix=".json")
+        with open(json_path, "w") as f:
+            json.dump(sequential_generator_params, f)
+        super().__init__(json_path)
+        self._update_end_frame(self.total_samples)
+        self._calculate_list_samples(self.total_samples)
+
+
+    def __getitem__(self, index):
+        # This is to ensure we are going through
+        # the entire data when steps_per_epoch<self.__len__
+        shuffle_indexes = self.generate_batch_indexes(index)
+
+        input_full = np.zeros(
+            [self.batch_size, self.desired_shape[0], self.desired_shape[1],
+             self.pre_frame + self.post_frame],
+            dtype="float32",
+        )
+        output_full = np.zeros(
+            [self.batch_size, self.desired_shape[0], self.desired_shape[1], 1], dtype="float32"
+        )
+
+        for batch_index, frame_index in enumerate(shuffle_indexes):
+            X, Y = self.__data_generation__(frame_index)
+
+            input_full[batch_index, :, :, :] = X
+            output_full[batch_index, :, :, :] = Y
+
+        return input_full, output_full
+
+
+    def __data_generation__(self, index_frame):
+        "Generates data containing batch_size samples"
+
+        # We reorganize to follow true geometry of probe for convolution
+        input_full = np.zeros(
+            [1, self.desired_shape[0], self.desired_shape[1],
+             self.pre_frame + self.post_frame], dtype="float32"
+        )
+        output_full = np.zeros([1, self.desired_shape[0], self.desired_shape[1], 1], dtype="float32")
+
+        start_frame = index_frame - self.pre_frame - self.pre_post_omission - 1
+        end_frame = index_frame + self.post_frame - self.pre_post_omission + 2
+        full_traces = self.recording.get_traces(start_frame=start_frame, end_frame=end_frame).atype("float32")
+
+        output_frame_index = self.pre_frame + self.pre_post_omission
+        mask = np.ones(len(full_traces), dtype=bool)
+        mask = np.ones(len(full_traces), dtype=bool)
+        mask[output_frame_index - 1:output_frame_index + 2] = False    
+
+        data_img_input = full_traces[mask]
+        data_img_output = full_traces[output_frame_index][np.newaxis, :]
+
+        # make 3d based on desired shape
+        data_input_3d = data_img_input.reshape((-1, self.desired_shape[0], self.desired_shape[1]))
+        data_output_3d = data_img_output.reshape((-1, self.desired_shape[0], self.desired_shape[1]))
+
+        input_full[0] = data_input_3d.swapaxes(0, 1).swapaxes(1, 2)
+        output_full[0] = data_output_3d.swapaxes(0, 1).swapaxes(1, 2)
+
+        return input_full, output_full

--- a/spikeinterface/spikeinterface_generator.py
+++ b/spikeinterface/spikeinterface_generator.py
@@ -85,8 +85,10 @@ class SpikeInterfaceGenerator(SequentialGenerator):
 
         start_frame = index_frame - self.pre_frame - self.pre_post_omission - 1
         end_frame = index_frame + self.post_frame - self.pre_post_omission + 2
-        full_traces = self.recording.get_traces(start_frame=start_frame, end_frame=end_frame).atype("float32")
-
+        full_traces = self.recording.get_traces(start_frame=start_frame, end_frame=end_frame).astype("float32")
+        
+        if full_traces.shape[0] == 0:
+            print(f"Error! {index_frame}-{start_frame}-{end_frame}", flush=True)
         output_frame_index = self.pre_frame + self.pre_post_omission
         mask = np.ones(len(full_traces), dtype=bool)
         mask = np.ones(len(full_traces), dtype=bool)
@@ -103,3 +105,7 @@ class SpikeInterfaceGenerator(SequentialGenerator):
         output_full[0] = data_output_3d.swapaxes(0, 1).swapaxes(1, 2)
 
         return input_full, output_full
+
+
+    def reshape_output(self, output):
+        return output.squeeze().reshape(-1, self.recording.get_num_channels())    

--- a/spikeinterface/spikeinterface_generator.py
+++ b/spikeinterface/spikeinterface_generator.py
@@ -83,8 +83,8 @@ class SpikeInterfaceGenerator(SequentialGenerator):
         )
         output_full = np.zeros([1, self.desired_shape[0], self.desired_shape[1], 1], dtype="float32")
 
-        start_frame = index_frame - self.pre_frame - self.pre_post_omission - 1
-        end_frame = index_frame + self.post_frame - self.pre_post_omission + 2
+        start_frame = index_frame - self.pre_frame - self.pre_post_omission
+        end_frame = index_frame + self.post_frame + self.pre_post_omission + 1
         full_traces = self.recording.get_traces(start_frame=start_frame, end_frame=end_frame).astype("float32")
         
         if full_traces.shape[0] == 0:

--- a/spikeinterface/spikeinterface_training.ipynb
+++ b/spikeinterface/spikeinterface_training.ipynb
@@ -17,6 +17,8 @@
     "import spikeinterface.preprocessing as spre\n",
     "import spikeinterface.widgets as sw\n",
     "\n",
+    "from tensorflow import keras\n",
+    "\n",
     "# the generator is in the \"spikeinterface_generator.py\"\n",
     "from spikeinterface_generator import SpikeInterfaceGenerator\n",
     "\n",
@@ -152,9 +154,9 @@
    "outputs": [],
    "source": [
     "start_frame_training = int(0 * rec_norm.sampling_frequency)\n",
-    "end_frame_training = int(0.1 * rec_norm.sampling_frequency)\n",
+    "end_frame_training = int(1 * rec_norm.sampling_frequency)\n",
     "start_frame_test = int(20 * rec_norm.sampling_frequency) \n",
-    "end_frame_test = int(20.05 * rec_norm.sampling_frequency)"
+    "end_frame_test = int(20.1 * rec_norm.sampling_frequency)"
    ]
   },
   {
@@ -166,24 +168,32 @@
    },
    "outputs": [],
    "source": [
-    "# Training (from Training class)\n",
+    "# Training (from core_trainor class)\n",
     "output_folder = Path(\"test_training\")\n",
     "output_folder.mkdir(exist_ok=True)\n",
     "\n",
-    "training_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False, \n",
+    "desired_shape = (192, 2)\n",
+    "pre_frame = 30\n",
+    "post_frame = 30\n",
+    "\n",
+    "training_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False,\n",
+    "                                                  pre_frame=pre_frame, post_frame=post_frame,\n",
     "                                                  start_frame=start_frame_training,\n",
-    "                                                  end_frame=end_frame_training)\n",
-    "test_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False, \n",
+    "                                                  end_frame=end_frame_training,\n",
+    "                                                  desired_shape=desired_shape)\n",
+    "test_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False,\n",
+    "                                              pre_frame=pre_frame, post_frame=post_frame,\n",
     "                                              start_frame=start_frame_test,\n",
-    "                                              end_frame=end_frame_test)\n",
+    "                                              end_frame=end_frame_test,\n",
+    "                                              steps_per_epoch=-1,\n",
+    "                                              desired_shape=desired_shape)\n",
     "\n",
     "\n",
-    " # Those are parameters used for the network topology\n",
+    "# Those are parameters used for the network topology\n",
     "network_params = dict()\n",
     "network_params[\"type\"] = \"network\"\n",
-    "network_params[\n",
-    "    \"name\"\n",
-    "] = \"unet_single_ephys_1024\"  # Name of network topology in the collection\n",
+    "# Name of network topology in the collection\n",
+    "network_params[\"name\"] = \"unet_single_ephys_1024\"\n",
     "\n",
     "network_json_path = output_folder / \"network_params.json\"\n",
     "with open(network_json_path, \"w\") as f:\n",
@@ -195,11 +205,7 @@
     "training_params = dict()\n",
     "training_params[\"loss\"] = \"mean_absolute_error\"\n",
     "\n",
-    "training_params[\"model_string\"] = (\n",
-    "    \"unet_single_ephys_1024\"\n",
-    "    + \"_\"\n",
-    "    + training_params[\"loss\"]\n",
-    ")\n",
+    "training_params[\"model_string\"] = f\"{network_params['name']}_{training_params['loss']}\"\n",
     "training_params[\"output_dir\"] = str(output_folder)\n",
     "# We pass on the uid\n",
     "training_params[\"run_uid\"] = \"first_test\"\n",
@@ -214,7 +220,9 @@
     "training_params[\"learning_rate\"] = 0.0001\n",
     "training_params[\"pre_post_frame\"] = 1\n",
     "training_params[\"loss\"] = \"mean_absolute_error\"\n",
-    "training_params[\"nb_workers\"] = 1\n",
+    "training_params[\"nb_workers\"] = 2\n",
+    "training_params[\"caching_validation\"] = False\n",
+    "\n",
     "\n",
     "training_json_path = output_folder / \"training_params.json\"\n",
     "with open(training_json_path, \"w\") as f:\n",
@@ -244,6 +252,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5f434c7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = \"test_training/first_test_unet_single_ephys_1024_mean_absolute_error_model.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38e65f3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path = output_folder / f\"{training_params['run_uid']}_{training_params['model_string']}_model.h5\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51c7663e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce79cd89",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keras.backend.clear_session()\n",
+    "model = keras.models.load_model(filepath=model_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d3e6377",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check shape (this will need to be done at inference)\n",
+    "network_input_shape = model.get_config()[\"layers\"][0][\"config\"][\"batch_input_shape\"]\n",
+    "assert network_input_shape[1:] == desired_shape + (pre_frame + post_frame,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "95cf3d42",
    "metadata": {},
    "outputs": [],
@@ -258,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output = training_class.local_model.predict(sample_input)\n",
+    "output = model.predict(sample_input)\n",
     "output_data = test_data_generator.reshape_output(output)\n",
     "input_data = original_data.squeeze().reshape(-1, recording.get_num_channels())"
    ]
@@ -270,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(ncols=2)\n",
+    "fig, axs = plt.subplots(ncols=2, sharex=True, sharey=True)\n",
     "axs[0].imshow(input_data.T, origin=\"lower\", cmap=\"RdGy_r\")\n",
     "axs[1].imshow(output_data.T, origin=\"lower\", cmap=\"RdGy_r\")"
    ]

--- a/spikeinterface/spikeinterface_training.py
+++ b/spikeinterface/spikeinterface_training.py
@@ -1,0 +1,147 @@
+import json
+import numpy as np
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+from tensorflow import keras
+
+import spikeinterface.extractors as se
+import spikeinterface.preprocessing as spre
+
+from deepinterpolation.trainor_collection import core_trainer
+from deepinterpolation.network_collection import unet_single_ephys_1024
+from deepinterpolation.generic import ClassLoader
+
+# the generator is in the "spikeinterface_generator.py"
+from spikeinterface_generator import SpikeInterfaceGenerator
+
+
+# Define training and testing constants (@Jad you can gradually increase this)
+TRAINING_START_S = 0
+TRAINING_END_S = 10
+TESTING_START_S = 100
+TESTING_END_S = 101
+DESIRED_SHAPE = (192, 2)
+
+
+pre_frame = 30
+post_frame = 30
+pre_post_omission = 1
+
+
+### Load NP2 dataset (and preprocess)
+
+# example of data generation in spike interface
+folder_path = "/home/alessio/Documents/data/allen/npix-open-ephys/595262_2022-02-22_16-47-26/"
+recording = se.read_openephys(folder_path)
+
+rec_f = spre.bandpass_filter(recording)
+rec_norm = spre.zscore(rec_f)
+
+### Test SpikeInterfaceGenerator behavior
+
+si_generator = SpikeInterfaceGenerator(rec_norm, batch_size=10, zscore=False)
+input_0, output_0 = si_generator[0]
+si_generator.batch_size
+
+print(f"Input shape: {input_0.shape}")
+print(f"Output shape: {output_0.shape}")
+
+
+### Perform small training
+
+start_frame_training = int(TRAINING_START_S * rec_norm.sampling_frequency)
+end_frame_training = int(TRAINING_END_S * rec_norm.sampling_frequency)
+start_frame_test = int(TESTING_START_S * rec_norm.sampling_frequency) 
+end_frame_test = int(TESTING_END_S * rec_norm.sampling_frequency)
+
+# Training (from core_trainor class)
+output_folder = Path("test_training")
+output_folder.mkdir(exist_ok=True)
+
+training_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False, 
+                                                  pre_frame=pre_frame, post_frame=post_frame,
+                                                  pre_post_omission=pre_post_omission,
+                                                  start_frame=start_frame_training,
+                                                  end_frame=end_frame_training,
+                                                  desired_shape=DESIRED_SHAPE)
+test_data_generator = SpikeInterfaceGenerator(rec_norm, zscore=False,
+                                              pre_frame=pre_frame, post_frame=post_frame,
+                                              pre_post_omission=pre_post_omission,
+                                              start_frame=start_frame_test,
+                                              end_frame=end_frame_test,
+                                              steps_per_epoch=-1,
+                                              desired_shape=DESIRED_SHAPE)
+
+
+# Those are parameters used for the network topology
+network_params = dict()
+network_params["type"] = "network"
+# Name of network topology in the collection
+network_params["name"] = "unet_single_ephys_1024"
+
+network_json_path = output_folder / "network_params.json"
+with open(network_json_path, "w") as f:
+    json.dump(network_params, f)
+
+network_obj = ClassLoader(network_json_path)
+data_network = network_obj.find_and_build()(network_json_path)
+
+training_params = dict()
+training_params["loss"] = "mean_absolute_error"
+
+training_params["model_string"] = f"{network_params['name']}_{training_params['loss']}"
+training_params["output_dir"] = str(output_folder)
+# We pass on the uid
+training_params["run_uid"] = "first_test"
+
+# We convert to old schema
+training_params["nb_gpus"] = 1
+training_params["type"] = "trainer"
+training_params["steps_per_epoch"] = 10
+training_params["period_save"] = 5
+training_params["apply_learning_decay"] = 0
+training_params["nb_times_through_data"] = 1
+training_params["learning_rate"] = 0.0001
+training_params["pre_post_frame"] = 1
+training_params["loss"] = "mean_absolute_error"
+training_params["nb_workers"] = 2
+training_params["caching_validation"] = False
+
+
+training_json_path = output_folder / "training_params.json"
+with open(training_json_path, "w") as f:
+    json.dump(training_params, f)
+
+
+training_class = core_trainer(
+    training_data_generator, test_data_generator, data_network,
+    training_json_path
+)
+
+print("created objects for training")
+training_class.run()
+
+print("training job finished - finalizing output model")
+training_class.finalize()
+
+### Test inference
+
+# Re-load model from output folder
+model_path = output_folder / f"{training_params['run_uid']}_{training_params['model_string']}_model.h5"
+keras.backend.clear_session()
+model = keras.models.load_model(filepath=model_path)
+
+# check shape (this will need to be done at inference)
+network_input_shape = model.get_config()["layers"][0]["config"]["batch_input_shape"]
+assert network_input_shape[1:] == DESIRED_SHAPE + (pre_frame + post_frame,)
+
+sample_input, original_data = test_data_generator[0]
+
+output = training_class.local_model.predict(sample_input)
+output_data = test_data_generator.reshape_output(output)
+input_data = original_data.squeeze().reshape(-1, recording.get_num_channels())
+
+fig, axs = plt.subplots(ncols=2)
+axs[0].imshow(input_data.T, origin="lower", cmap="RdGy_r")
+axs[1].imshow(output_data.T, origin="lower", cmap="RdGy_r")


### PR DESCRIPTION
@Jad-Selman @jeromelecoq 

Here is a tidied up version of what we worked on today.

The `SpikeInterfaceGenerator` class can be instantiated with a `SpikeInterface BaseRecording`  object and other parameters. It can then be used directly for training and inference. Note that the shape `(192,2)` works out of the box for NP2.0!

For other geometries, so far, we would need to provide the desired shape.

Another comment:
The normalization is performed directly with the spikeinterface `zscore` function